### PR TITLE
Check if getQuery returns array or object

### DIFF
--- a/Observer/Predispatch.php
+++ b/Observer/Predispatch.php
@@ -59,7 +59,11 @@ class Predispatch implements ObserverInterface {
             }
 
             // Pass on any query parameters to the configurable product's URL.
-            $query = $request->getQuery() ? '?' . http_build_query($request->getQuery()) : '';
+            $query = $request->getQuery();
+            if (is_object($query)) {
+                $query = $query->toArray();
+            }
+            $query = $query ? '?' . http_build_query($query) : '';
 
             // Generate hash for selected product options.
             $hash = $options ? '#' . http_build_query($options) : '';


### PR DESCRIPTION
When the getQuery returns an object (eg Laminas Parameter object) it's always true. This creates an URL with `.html?#a=b` which doesn't work. When corrected, it does work though.